### PR TITLE
Corrige ortografia em cgnatgen

### DIFF
--- a/cgnatgen-0.2-beta.sh
+++ b/cgnatgen-0.2-beta.sh
@@ -24,7 +24,7 @@ while : ; do
                 Defina o nome do arquivo, executando o programa
                 com o nome como parâmetro. Ex.:
                 ./cgnatgen.sh arquivo.rsc
-                Se não for defindo, será gerado como mk-cgnat.rsc
+                Se não for definido, será gerado como mk-cgnat.rsc
                 Atualmente o nome é: $arquivo
                 Informe o bloco privado, com a máscara.
                 Ex.: 100.100.0.0/20" 0 0 )

--- a/cgnatgen.sh
+++ b/cgnatgen.sh
@@ -24,7 +24,7 @@ while : ; do
                 Defina o nome do arquivo, executando o programa
                 com o nome como parâmetro. Ex.:
                 ./cgnatgen.sh arquivo.rsc
-                Se não for defindo, será gerado como mk-cgnat.rsc
+                Se não for definido, será gerado como mk-cgnat.rsc
                 Atualmente o nome é: $arquivo
                 Informe o bloco(pool) privado, com a máscara.
                 Ex.: 100.100.0.0/20" 0 0 )


### PR DESCRIPTION
## Summary
- corrigir texto de "defindo" para "definido" em cgnatgen.sh e cgnatgen-0.2-beta.sh
- manter scripts executáveis

## Testing
- `./cgnatgen.sh`
- `./cgnatgen-0.2-beta.sh`


------
https://chatgpt.com/codex/tasks/task_e_6845b97d140083289eecf7079628f3a5