### PR TITLE
Fix overlap check condition

### DIFF
--- a/cgnatgen-1.0.sh
+++ b/cgnatgen-1.0.sh
@@ -193,7 +193,7 @@ get_input() {
             done
         done
 
-        if $overlap_found; then
+        if [[ "$overlap_found" == true ]]; then
             continue
         fi
 


### PR DESCRIPTION
## Summary
- ensure boolean comparison of `overlap_found` when validating public prefix overlap

## Testing
- `bash cgnatgen-1.0.sh` *(fails: missing dialog and bc)*

------
https://chatgpt.com/codex/tasks/task_e_6845b9856dcc8328aa9433d65946919c